### PR TITLE
对 API-global 中的一些定时标识类型的修正

### DIFF
--- a/api/md0.md
+++ b/api/md0.md
@@ -49,7 +49,7 @@ confirm('is ok?', {
 
 `time`: int 毫秒
 
-`返回值`: string 事件标识
+`返回值`: int 事件标识
 
 示例：
 
@@ -63,7 +63,7 @@ setTimeout(function () {
 
 `参数`:
 
-`id`: string 事件标识
+`id`: int 事件标识
 
 ## setInterval(function,time)
 
@@ -73,7 +73,7 @@ setTimeout(function () {
 
 `time`: int 毫秒
 
-`返回值`: string 事件标识
+`返回值`: int 事件标识
 
 示例：
 
@@ -87,4 +87,4 @@ setInterval(function () {
 
 `参数`:
 
-`id`: string 事件标识
+`id`: int 事件标识


### PR DESCRIPTION
MDN上关于标识的定义是非零数值：

https://developer.mozilla.org/zh-CN/docs/Web/API/setInterval#%E8%BF%94%E5%9B%9E%E5%80%BC

实机测试获取到的也是`number`数值。
