### PR TITLE
对 API-crypto 中的一些哈希函数返回值类型的修正

### DIFF
--- a/api/md5.md
+++ b/api/md5.md
@@ -112,7 +112,7 @@
 
 `data`: byte[]
 
-`返回值`: byte[]
+`返回值`: string
 
 ## crypto.sha1(data)
 
@@ -128,7 +128,7 @@
 
 `data`: byte[]
 
-`返回值`: byte[]
+`返回值`: string
 
 ## crypto.sha256(data)
 
@@ -144,4 +144,4 @@
 
 `data`: byte[]
 
-`返回值`: byte[]
+`返回值`: string


### PR DESCRIPTION
实机测试发现所有哈希相关函数的返回值都是hex化的string类型，与是否为Bytes后缀函数无关。

![5D916B215B539B2EC2262E539A207C45](https://github.com/JsHookApp/Document/assets/21287731/0f104d85-9b2d-43a4-9f42-47924af52fb1)

